### PR TITLE
Adds method to Request struct

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -22,6 +22,7 @@ type Request struct {
 	Body        []byte
 	Header      http.Header
 	QueryString string
+	Method      string
 }
 
 // FunctionHandler used for a serverless Go method invocation


### PR DESCRIPTION
## Testing
1. faas template pull  https://github.com/openfaas-incubator/golang-http-template
2. faas new go-http --lang golang-http
3. Modified template to include code changes from this PR and https://github.com/openfaas-incubator/golang-http-template/pull/13

Function code:
```golang
// Handle a function invocation
func Handle(req handler.Request) (handler.Response, error) {
	var err error

	message := fmt.Sprintf("Hello world, method was: %s", req.Method)

	return handler.Response{
		Body:       []byte(message),
		StatusCode: http.StatusOK,
	}, err
}
```

Tests
```
curl http://127.0.0.1:8080/function/go-http
Hello world, method was: GET

 curl http://127.0.0.1:8080/function/go-http -X POST
Hello world, method was: POST⏎
```
