### PR TITLE
Include Host string in Request

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -23,6 +23,7 @@ type Request struct {
 	Header      http.Header
 	QueryString string
 	Method      string
+	Host        string
 }
 
 // FunctionHandler used for a serverless Go method invocation


### PR DESCRIPTION
The Host string provides us with a mechanism for extracting the function name, which we, in turn, require for things like function-level access control with OPA.

Resolves #2  
 
Signed-off-by: Paul Mundt <paul.mundt@adaptant.io>